### PR TITLE
Fix: Ensure consistent naming for /prove

### DIFF
--- a/src/templates/partials/tx_details.html
+++ b/src/templates/partials/tx_details.html
@@ -180,7 +180,7 @@
             </p>
             <form action="/myoutputs" method="post" class="pure-form">
               <input type="hidden" name="tx_hash" value="{{tx_hash}}"/>
-              <input type="text" name="gntl_address" placeholder="GNTL address/subaddress" class="pure-input-1" />
+              <input type="text" name="gntladdress" placeholder="GNTL address/subaddress" class="pure-input-1" />
               <input type="text" name="viewkey" placeholder="Private viewkey" class="pure-input-1" />
               <input type="hidden" name="raw_tx_data" value="{{raw_tx_data}}" />
               <!--above raw_tx_data field only used when checking raw tx data through tx pusher-->
@@ -205,7 +205,7 @@
               <input type="text" name="txprvkey" placeholder="Tx private key" class="pure-input-1" />
               <input type="hidden" name="raw_tx_data" value="{{raw_tx_data}}" />
               <!--above raw_tx_data field only used when checking raw tx data through tx pusher-->
-              <input type="text" name="gntl_address" placeholder="Recipient's GNTL address/subaddress" class="pure-input-1" />
+              <input type="text" name="gntladdress" placeholder="Recipient's GNTL address/subaddress" class="pure-input-1" />
 
               <input type="submit" value="Prove sending" class="pure-button pure-button-active" />
             </form>


### PR DESCRIPTION
This commit fixes the inconsistency in the naming of the recipient GNTL address field between the HTML form and the server-side code in main.cpp. Previously, the form used "gntl_address", while the server code expected "gntladdress", causing form submissions to fail.

Changes made:
- Updated tx_details.html to use the correct field name gntladdress in the form fields.
- Verified that all instances in the main.cpp are aligned with the form field names.