### PR TITLE
Fix form and backend variable name inconsistencies

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -386,17 +386,17 @@ main(int ac, const char* av[])
             map<std::string, std::string> post_body
                     = gntleg::parse_crow_post_data(req.body);
 
-            if (post_body.count("gntladdress") == 0
-                || post_body.count("txprvkey") == 0
-                || post_body.count("txhash") == 0)
+            if (post_body.count("gntl_address") == 0
+                || post_body.count("tx_prv_key") == 0
+                || post_body.count("tx_hash") == 0)
             {
                 return string("GNTL address, tx private key or "
                                       "tx hash not provided");
             }
 
-            string tx_hash     = remove_bad_chars(post_body["txhash"]);
-            string tx_prv_key  = remove_bad_chars(post_body["txprvkey"]);
-            string gntl_address = remove_bad_chars(post_body["gntladdress"]);
+            string tx_hash     = remove_bad_chars(post_body["tx_hash"]);
+            string tx_prv_key  = remove_bad_chars(post_body["tx_prv_key"]);
+            string gntl_address = remove_bad_chars(post_body["gntl_address"]);
 
             // this will be only not empty when checking raw tx data
             // using tx pusher

--- a/src/templates/partials/tx_details.html
+++ b/src/templates/partials/tx_details.html
@@ -201,8 +201,8 @@
               Note: address/subaddress and tx private key are sent to the server, as the calculations are done on the server side
             </p>
             <form action="/prove" method="post" class="pure-form">
-              <input type="hidden" name="txhash" value="{{tx_hash}}" />
-              <input type="text" name="txprvkey" placeholder="Tx private key" class="pure-input-1" />
+              <input type="hidden" name="tx_hash" value="{{tx_hash}}" />
+              <input type="text" name="tx_prv_key" placeholder="Tx private key" class="pure-input-1" />
               <input type="hidden" name="raw_tx_data" value="{{raw_tx_data}}" />
               <!--above raw_tx_data field only used when checking raw tx data through tx pusher-->
               <input type="text" name="gntl_address" placeholder="Recipient's GNTL address/subaddress" class="pure-input-1" />


### PR DESCRIPTION
Updated main.cpp to expect tx_hash, tx_prv_key, and gntl_address instead of txhash, txprvkey, and gntladdress.

Updated the form in tx_details.html to use the correct input names.